### PR TITLE
use mkdir -p to avoid some dir creation errors that can occur sometim…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ MAMEOS = libretro
 VPATH=src $(wildcard src/cpu/*)
 
 # compiler, linker and utilities
-MD = @mkdir
+MD = @mkdir -p
 RM = rm -f
 
 EMULATOR = $(TARGET)


### PR DESCRIPTION
…es when building with -jX

Solves problems that sometimes happen like

/bin/mkdir: cannot create directory `obj/cpu/adsp2100': No such file or directory

(Because parent folder was not yet created). builds perfectly with -j8 etc with this change.
