### PR TITLE
don't enable asm cpu cores Cyclone and DrZ80 by default. They cause i…

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1771,12 +1771,19 @@ CPUDEFS += -DHAS_ARM=1
 SOURCES_C += $(CORE_DIR)/src/cpu/arm/arm.c
 endif
 
-ifneq ($(ARM),)
+ifeq ($(ARM), 1)
 	DEFS += -DIS_ARM=1
-	CPUDEFS += -DHAS_CYCLONE=1 -DHAS_DRZ80=1
+endif
+
+ifeq ($(USE_CYCLONE), 1)
+	DEFS += -DHAS_CYCLONE=1
 	SOURCES_ASM += $(CORE_DIR)/src/cpu/m68000_cyclone/cyclone.s \
-				  $(CORE_DIR)/src/cpu/m68000_cyclone/c68000.s \
-				  $(CORE_DIR)/src/cpu/z80_drz80/drz80.s \
+				  $(CORE_DIR)/src/cpu/m68000_cyclone/c68000.s
+endif
+
+ifeq ($(USE_DRZ80), 1)
+	DEFS += -DHAS_DRZ80=1
+	SOURCES_ASM += $(CORE_DIR)/src/cpu/z80_drz80/drz80.s \
 				  $(CORE_DIR)/src/cpu/z80_drz80/drz80_z80.s
 endif
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -6,3 +6,13 @@ If you are compiling it for an ARM system, add "ARM=1" to the end of the
 command, like this:
 
 make ARM=1
+
+There are two additional ASM optimised CPU cores that can be used for
+ARM. Cyclone for 68k emulation and DRZ80 for z80. They can bring a
+speedup and may be of use for older cpus, but reduce compatibility.
+To enable them pass USE_CYCLONE=1 and/or USE_DRZ80=1 to make.
+
+eg.
+
+make ARM=1 USE_CYCLONE=1 USE_DRZ80=1
+ 


### PR DESCRIPTION
…ncompatibilities with games and

drz80 uses armv6 instructions that are deprecated/emulated on armv7 and higher (gcc will reject them building for armv8).
The ASM cores can be enabled with USE_CYCLONE=1 and/or USE_DRZ80=1