### PR TITLE
use -fsigned-char on ARM to solve potential problems with code writte…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,10 @@ X86_DEFINES = -Dasm="__asm__ __volatile__"
 CFLAGS +=  $(X86_DEFINES)
 endif
 
+ifeq ($(ARM), 1)
+   CFLAGS += -fsigned-char
+endif
+
 ifeq ($(DEBUG), 1)
 	CFLAGS += -O0 -g
 else


### PR DESCRIPTION
…n/tested on x86 - eg on mame2003 audio on rtype leo is wrong without it.