### PR TITLE
compile asm drivers for cyclone and drz80 on arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,8 @@ endif
 
 ifeq ($(ARM), 1)
    CFLAGS += -fsigned-char
+   USE_CYCLONE = 1
+   USE_DRZ80 = 1
 endif
 
 ifeq ($(DEBUG), 1)

--- a/src/cpu/z80_drz80/drz80.s
+++ b/src/cpu/z80_drz80/drz80.s
@@ -4082,9 +4082,13 @@ opcode_0_7:
 ;@EX AF,AF'
 opcode_0_8:
 	add r1,cpucontext,#z80a2
-	swp z80a,z80a,[r1]
+	ldr r0,[r1]
+        str z80a,[r1]
+        mov z80a,r0
 	add r1,cpucontext,#z80f2
-	swp z80f,z80f,[r1]
+	ldr r0,[r1]
+        str z80f,[r1]
+        mov z80f,r0
 	fetch 4
 ;@ADD HL,BC
 opcode_0_9:
@@ -5138,11 +5142,17 @@ opcode_D_8:
 ;@EXX
 opcode_D_9:
 	add r1,cpucontext,#z80bc2
-	swp z80bc,z80bc,[r1]
-	add r1,cpucontext,#z80de2
-	swp z80de,z80de,[r1]
+        ldr r0,[r1]
+        str z80bc,[r1]
+        mov z80bc,r0
+        add r1,cpucontext,#z80de2
+	ldr r0,[r1]
+        str z80de,[r1]
+        mov z80de,r0
 	add r1,cpucontext,#z80hl2
-	swp z80hl,z80hl,[r1]
+	ldr r0,[r1]
+        str z80hl,[r1]
+        mov z80hl,r0
 	fetch 4
 ;@JP C,$+3
 opcode_D_A:


### PR DESCRIPTION
As @dankcushions suggested in https://github.com/libretro/mame2000-libretro/issues/40#issuecomment-312185221 this would use the assembly version of the drivers for these two cpus, as is done with mame4all.

Hopefully this will address the performance difference between mame2000 and mame4all on rPi boards, however I don't have any arm hardware to test this on. @herbfargus & @hizzlekizzle you also posted in the issue so I'm going to tag you here in case you have input on this PR.