### PR TITLE
temporarily remove arm dynarecs pending mame4all-pi port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,8 +309,8 @@ endif
 
 ifeq ($(ARM), 1)
    CFLAGS += -fsigned-char
-   USE_CYCLONE = 1
-   USE_DRZ80 = 1
+#   USE_CYCLONE = 1
+#   USE_DRZ80 = 1
 endif
 
 ifeq ($(DEBUG), 1)


### PR DESCRIPTION
It seems like the right way to incorporate these two dynarecs is to port the internal compatibility table described in this post: https://github.com/libretro/mame2000-libretro/pull/46#issuecomment-338247862

I'll open a new issue to track progress towards that goal.