### PR TITLE
Fix compilation with DEBUG=1

### DIFF
--- a/src/vidhrdw/taitosj.c
+++ b/src/vidhrdw/taitosj.c
@@ -399,7 +399,7 @@ WRITE_HANDLER( taitosj_collision_reg_clear_w )
 	taitosj_collision_reg[3] = 0;
 }
 
-INLINE int get_sprite_xy(UINT8 num, UINT8* sx, UINT8* sy)
+static INLINE int get_sprite_xy(UINT8 num, UINT8* sx, UINT8* sy)
 {
 	int offs = num * 4;
 


### PR DESCRIPTION
./src/drivers/taitosj.o: In function `check_sprite_sprite_collision':
./src/drivers/../vidhrdw/taitosj.c:488: undefined reference to `get_sprite_xy'
./src/drivers/../vidhrdw/taitosj.c:496: undefined reference to `get_sprite_xy'
./src/drivers/taitosj.o: In function `calculate_sprites_areas':
./src/drivers/../vidhrdw/taitosj.c:533: undefined reference to `get_sprite_xy'
./src/drivers/taitosj.o: In function `drawsprites':
./src/drivers/../vidhrdw/taitosj.c:670: undefined reference to `get_sprite_xy'