### PR TITLE
fix iOS and tvOS build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ else ifneq (,$(findstring ios,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro_ios.dylib
 	fpic := -fPIC
 	SHARED := -dynamiclib
+	CFLAGS += -DHAVE_POSIX_MEMALIGN
 
 ifeq ($(IOSSDK),)
    IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)


### PR DESCRIPTION
Add in correct HAVE_POSIX_MEMALIGN Flag for compilation. Now correctly compiles a core for the arm64 architecture.