### PR TITLE
Correct way to compare string

### DIFF
--- a/src/sndhrdw/astrocde.c
+++ b/src/sndhrdw/astrocde.c
@@ -147,7 +147,7 @@ READ_HANDLER( wow_speech_r )
 				totalword[0] = 0;				   /* Clear the total word stack */
 				return data;
 	}
-	if (PhonemeTable[Phoneme] == "PA0")						   /* We know PA0 is never part of a word */
+	if (strcmp(PhonemeTable[Phoneme], "PA0")==0)						   /* We know PA0 is never part of a word */
 				totalword[0] = 0;				   /* Clear the total word stack */
 
 /* Phoneme to word translation */


### PR DESCRIPTION
This line cause errors in compiler checking. https://build.opensuse.org/package/live_build_log/Emulators/libretro-mame2003/openSUSE_Leap_15.1/x86_64

I followed this https://www.wikihow.com/Compare-Two-Strings-in-C-Programming