### PR TITLE
Fic vector games

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,16 @@ IS_X86 = 0
 TARGET_NAME = mame2000
 
 CORE_DIR = .
+CFLAGS += -fsigned-char
 
 ifeq (,$(findstring msvc,$(platform)))
 GCC_DEFINES := -Wno-sign-compare -Wunused -Wpointer-arith -Waggregate-return -Wshadow
+endif
+
+ifneq ($(SANITIZER),)
+   CFLAGS   := -fsanitize=$(SANITIZER) $(CFLAGS)
+   CXXFLAGS := -fsanitize=$(SANITIZER) $(CXXFLAGS)
+   LDFLAGS  := -fsanitize=$(SANITIZER) $(LDFLAGS)
 endif
 
 GIT_VERSION ?= " $(shell git rev-parse --short HEAD || echo unknown)"

--- a/src/drivers/tempest.c
+++ b/src/drivers/tempest.c
@@ -377,7 +377,7 @@ static struct MachineDriver machine_driver_tempest =
 	0,
 
 	/* video hardware */
-	300, 400, { 0, 550, 0, 580 },
+	400, 300, { 0, 580, 0, 570 },
 	0,
 	256,0,
 	avg_init_palette_multi,

--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -81,7 +81,6 @@ extern short *samples_buffer;
 extern short *conversion_buffer;
 extern int joy_pressed[40];
 extern int key[KEY_MAX];
-
 extern char *nvdir, *hidir, *cfgdir, *inpdir, *stadir, *memcarddir;
 extern char *artworkdir, *screenshotdir, *alternate_name;
 extern char *cheatdir;
@@ -657,15 +656,17 @@ void retro_get_system_info(struct retro_system_info *info)
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
+   
+   float aspect_ratio = Machine->orientation & ORIENTATION_SWAP_XY? ( (float) 3 / (float) 4) : ( (float) 4/ (float) 3);
 #ifndef WANT_LIBCO
    lock_mame();
 #endif
    struct retro_game_geometry g = {
-      Machine->drv->screen_width,
-      Machine->drv->screen_height,
-      Machine->drv->screen_width,
-      Machine->drv->screen_height,
-      ((float) Machine->drv->screen_width / Machine->drv->screen_height) * ((Machine->drv->video_attributes & VIDEO_PIXEL_ASPECT_RATIO_MASK) == VIDEO_PIXEL_ASPECT_RATIO_1_2 ? 0.5f : 1.0f)
+     emulated_width,
+      emulated_height,
+      emulated_width,
+      emulated_height,
+      aspect_ratio
    };
    struct retro_system_timing t = {
       Machine->drv->frames_per_second,

--- a/src/libretro/video.c
+++ b/src/libretro/video.c
@@ -65,7 +65,7 @@ int wait_vsync;
 int vsync_frame_rate;
 int skiplines;
 int skipcolumns;
-int use_dirty;
+int use_dirty = -1;
 float osd_gamma_correction = 1.0;
 int brightness;
 float brightness_paused_adjust;
@@ -476,11 +476,10 @@ Returns 0 on success.
 */
 int osd_create_display(int width,int height,int depth,int fps,int attributes,int orientation)
 {
-	logerror("width %d, height %d\n", width,height);
+	printf("width %d, height %d\n", width,height);
 
 	video_depth = depth;
 	video_fps = fps;
-
 	brightness = 100;
 	brightness_paused_adjust = 1.0;
 	dirty_bright = 1;

--- a/src/mame.c
+++ b/src/mame.c
@@ -64,8 +64,8 @@ int run_game(int game)
 
     if(!iOS_fixedRes)
     {
-	  if (options.vector_width == 0) options.vector_width = 640;
-	  if (options.vector_height == 0) options.vector_height = 480;
+	  options.vector_width = 640;
+	  options.vector_height = 480;
     }
     else
     {


### PR DESCRIPTION
This will fix vector games not working and  fix aspect ratios when rotating a game. Also added asan to makefile. This pr doesn't include https://github.com/libretro/mame2000-libretro/pull/86 which is need for buffer overflows



