### PR TITLE
fix build with gcc-14

### DIFF
--- a/src/cheat.c
+++ b/src/cheat.c
@@ -2127,7 +2127,7 @@ INT32 ViewSearchResults (struct osd_bitmap *bitmap, INT32 selected)
 
 void RestoreSearch (void)
 {
-	int restoreString = NULL;	/* Steph */
+	int restoreString = 0;	/* Steph */
 
 	switch (restoreStatus)
 	{


### PR DESCRIPTION
restoreString should be set to 0 not NULL.

Fix the following compile error:
src/cheat.c: In function 'RestoreSearch':
src/cheat.c:2130:29: error: initialization of 'int' from 'void *' makes integer from pointer without a cast [-Wint-conversion]
 2130 |         int restoreString = NULL;       /* Steph */
      |                             ^~~~