### PR TITLE
Restore missing Wii U compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ else ifeq ($(platform), wiiu)
    CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
    ENDIANNESS_DEFINES := -DMSB_FIRST
-   PLATFORM_DEFINES += -DGEKKO -DWIIU -DHW_RVL -mwup -mcpu=750 -meabi -mhard-float
+   PLATFORM_DEFINES += -DGEKKO -DWIIU -DHW_RVL -D__wiiu__ -DHW_WUP -ffunction-sections -fdata-sections -mcpu=750 -meabi -mhard-float
    PLATFORM_DEFINES += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
    HAVE_RZLIB := 1
    STATIC_LINKING := 1


### PR DESCRIPTION
Proactive buildfix per https://github.com/libretro/RetroArch/pull/14925, which will necessitate an update of the Wii U toolchain to a version which no longer supports the `-mwup` flag. Safe to merge now; new flags are synonymous and function in both old and new toolchains.