### PR TITLE
[LIBRETRO] usrintrf: disable "UI Cancel" event when there is no OSD menu

### DIFF
--- a/src/usrintrf.c
+++ b/src/usrintrf.c
@@ -3450,8 +3450,10 @@ if (Machine->gamedrv->flags & GAME_COMPUTER)
 
 	/* if the user pressed ESC, stop the emulation */
 	/* but don't quit if the setup menu is on screen */
+#ifndef __LIBRETRO__
 	if (setup_selected == 0 && input_ui_pressed(IPT_UI_CANCEL))
 		return 1;
+#endif
 
 	if (setup_selected == 0 && input_ui_pressed(IPT_UI_CONFIGURE))
 	{


### PR DESCRIPTION
otherwise when pressing ESC the libretro core abruptly hangs.

~~My guess is it was mostly for OE mame to exit back to frontend browser with ROM selection menu (that's the case atleast in mame4all).~~ In original 037b5 MAME it just exit emulator.